### PR TITLE
Use PHP 7 versions of string handling macros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For examples of using this library, look at the [PCS extension](https://github.c
 
 # Usage
 
-Using the library is simple. Download the latest release from the [github repository](https://github.com/flaupretre/pecl-compat/releases) and insert it in your code tree. Then, include the 'compat.h' file in every '.c' source file.
+Using the library is simple. Download the latest release from the [github repository](https://github.com/flaupretre/pecl-compat/releases) and insert it in your code tree. Then, include the 'compat.h' file in every '.c' source file **after** the normal PHP includes.
 
 # History
 

--- a/compat.h
+++ b/compat.h
@@ -104,5 +104,6 @@
 #include "src/misc.h"
 #include "src/zend_string.h"
 #include "src/zend_hash.h"
+#include "src/zend_API.h"
 
 #endif /* _COMPAT_H */

--- a/src/zend_API.h
+++ b/src/zend_API.h
@@ -1,0 +1,76 @@
+/*
+  +----------------------------------------------------------------------+
+  | Compatibility macros for different PHP versions                      |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2016 The PHP Group                                     |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt.                                 |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Adam Harvey <aharvey@php.net>                                |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef _COMPAT_ZEND_API_H
+#define _COMPAT_ZEND_API_H
+
+#ifdef PHP_7
+/*============================================================================*/
+
+#else
+/*== PHP 5 ===================================================================*/
+
+/*
+ * Many string-related macros used to take duplicate parameters, which
+ * specified whether the string should be duplicated or not. In practice,
+ * almost all code used 1, so PHP 7 always duplicates.
+ *
+ * This header redefines the relevant macros to match PHP 7.
+ */
+
+#undef ZVAL_STRING
+#define ZVAL_STRING(z, s) do { \
+		const char *__s = (s); \
+		zval *__z = (z); \
+		Z_STRLEN_P(__z) = strlen(__s); \
+		Z_STRVAL_P(__z) = estrndup(__s, Z_STRLEN_P(__z)); \
+		Z_TYPE_P(__z) = IS_STRING; \
+	} while (0)
+
+#undef ZVAL_STRINGL
+#define ZVAL_STRINGL(z, s, l) do { \
+		const char *__s = (s); \
+		int __l = (l); \
+		zval *__z = (z); \
+		Z_STRLEN_P(__z) = __l; \
+		Z_STRVAL_P(__z) = estrndup(__s, __l); \
+		Z_TYPE_P(__z) = IS_STRING; \
+	} while (0)
+
+#undef RETVAL_STRING
+#define RETVAL_STRING(s)     ZVAL_STRING(return_value, (s))
+
+#undef RETVAL_STRINGL
+#define RETVAL_STRINGL(s, l) ZVAL_STRINGL(return_value, (s), (l))
+
+#undef RETURN_STRING
+#define RETURN_STRING(s)     { RETVAL_STRING(s); return; }
+
+#undef RETURN_STRINGL
+#define RETURN_STRINGL(s, l) { RETVAL_STRINGL(s, l); return; }
+
+#undef add_assoc_string
+#define add_assoc_string(__arg, __key, __str) add_assoc_string_ex(__arg, __key, strlen(__key)+1, __str, 1)
+
+#undef add_assoc_stringl
+#define add_assoc_stringl(__arg, __key, __str, __len) add_assoc_stringl_ex(__arg, __key, strlen(__key)+1, __str, __len, 1)
+
+#endif /* PHP_7 */
+/*============================================================================*/
+
+#endif /* _COMPAT_ZEND_API_H */


### PR DESCRIPTION
PHP 5 has a set of string zval handling macros that require a "duplicate" parameter that determines whether the input string will be duplicated or not. In PHP 7, they are always duplicated. This redefines the PHP 5 macros to match that behaviour.

This requires that the compatibility headers come in after all PHP includes, but I think that was likely the case anyway.
